### PR TITLE
Improve wordsearch

### DIFF
--- a/lib/screens.dart
+++ b/lib/screens.dart
@@ -1238,7 +1238,9 @@ class _WordSearchScreenState extends State<WordSearchScreen> {
     final allWords = List<Word>.from(widget.words)
         .where((w) {
           final trimmed = w.target.trim();
-          return !trimmed.contains(' ') && trimmed.length <= _gridSize;
+          // Exclude words with spaces or punctuation
+          final hasPunctuation = RegExp(r'[\p{P}]', unicode: true).hasMatch(trimmed);
+          return !trimmed.contains(' ') && !hasPunctuation && trimmed.length <= _gridSize;
         })
         .toList();
     allWords.shuffle(rand);


### PR DESCRIPTION
Improve grid word search:
- Try to overlap between words (but only horizontally vs vertically) (closes #21)
- Prevent placing two words directly below or next to eachother in the same direction
- Fixed dimensions: 10x10 grid with 12 placed words
- Do not place any words with spaces or punctuation (closes #13)
- Show all found words at the bottom