### PR TITLE
Ensure the search grid is filled with the target alphabet

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -341,6 +341,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  unicode_data:
+    dependency: "direct main"
+    description:
+      name: unicode_data
+      sha256: "8e01a9655fc08d3540ec8bb730a9b0cb59fa10f455c6c18ad11e99070539d988"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0-nullsafety.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  unicode_data: ^0.2.0-nullsafety.0
   shared_preferences: ^2.2.2
   csv: ^6.0.0
   file_picker: ^10.2.0


### PR DESCRIPTION
Closes #18 

For now, contains some hard-coded lists for common languages. Using `unicode_data` to define all characters from a language would otherwise pull in too many oddities like È etc.