### PR TITLE
Unit tests for connect screen and refactor of color names

### DIFF
--- a/lib/connect_screen.dart
+++ b/lib/connect_screen.dart
@@ -1,6 +1,14 @@
 import 'package:flutter/material.dart';
 import 'dart:math';
 
+// Color definitions for ConnectScreen
+const Color boxC = Colors.white;
+const Color boxConnectedC = Colors.grey;
+const Color boxSelectedC = Colors.amber;
+const Color borderConnectedC = Colors.grey;
+const Color borderDefaultC = Colors.blueGrey;
+const Color lineC = Colors.greenAccent;
+
 class ConnectScreen extends StatefulWidget {
   final List<Map<String, String>> wordPairs;
   ConnectScreen({Key? key, required this.wordPairs}) : super(key: key);
@@ -175,9 +183,9 @@ class _ConnectScreenState extends State<ConnectScreen> {
                                         padding: EdgeInsets.all(12),
                                         height: wordHeight,
                                         decoration: BoxDecoration(
-                                          color: isSelected ? Colors.amber[100] : isConnected ? Colors.grey[300] : Colors.white,
+                                          color: isSelected ? boxSelectedC : isConnected ? boxConnectedC : boxC,
                                           border: Border.all(
-                                            color: isConnected ? Colors.grey : Colors.blueGrey,
+                                            color: isConnected ? borderConnectedC : borderDefaultC,
                                             width: 2,
                                           ),
                                           borderRadius: BorderRadius.circular(8),
@@ -202,9 +210,9 @@ class _ConnectScreenState extends State<ConnectScreen> {
                                         padding: EdgeInsets.all(12),
                                         height: wordHeight,
                                         decoration: BoxDecoration(
-                                          color: isSelected ? Colors.amber[100] : isConnected ? Colors.grey[300] : Colors.white,
+                                          color: isSelected ? boxSelectedC : isConnected ? boxConnectedC : boxC,
                                           border: Border.all(
-                                            color: isConnected ? Colors.grey : Colors.blueGrey,
+                                            color: isConnected ? borderConnectedC : borderDefaultC,
                                             width: 2,
                                           ),
                                           borderRadius: BorderRadius.circular(8),
@@ -272,7 +280,7 @@ class _ConnectionLinePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = Colors.greenAccent
+      ..color = lineC
       ..strokeWidth = 4.0
       ..style = PaintingStyle.stroke;
     double leftX = width * 0.25;

--- a/lib/flashcard_screen.dart
+++ b/lib/flashcard_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'vocabulary.dart';
 
+// Color definitions for FlashcardScreen
+const Color correctC = Colors.green;
+const Color incorrectC = Colors.red;
+
 class FlashcardScreen extends StatefulWidget {
   final Vocabulary vocabulary;
   final int count;
@@ -112,8 +116,8 @@ class _FlashcardScreenState extends State<FlashcardScreen> {
             children: [
               Text('Quiz complete!', style: Theme.of(context).textTheme.headlineSmall),
               const SizedBox(height: 16),
-              Text('Correct:  $_correct', style: const TextStyle(color: Colors.green, fontSize: 18)),
-              Text('Incorrect:  $_incorrect', style: const TextStyle(color: Colors.red, fontSize: 18)),
+              Text('Correct:  $_correct', style: const TextStyle(color: correctC, fontSize: 18)),
+              Text('Incorrect:  $_incorrect', style: const TextStyle(color: incorrectC, fontSize: 18)),
               const SizedBox(height: 8),
               Text('Total score: ${percent.toStringAsFixed(1)}%', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
               const SizedBox(height: 24),
@@ -183,7 +187,7 @@ class _FlashcardScreenState extends State<FlashcardScreen> {
                   ] else ...[
                     Text(
                       _feedback!,
-                      style: TextStyle(fontSize: 20, color: _feedback!.startsWith('Correct!') ? Colors.green : Colors.red),
+                      style: TextStyle(fontSize: 20, color: _feedback!.startsWith('Correct!') ? correctC : incorrectC),
                       softWrap: true,
                       maxLines: null,
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'practice_screen.dart';
 import 'vocabulary_screen.dart';
 
+// Color definitions for MainScreen
+const Color selectedC = Colors.blue;
+const Color unselectedC = Colors.grey;
+
 void main() {
   runApp(const LexikonApp());
 }
@@ -63,8 +67,8 @@ class _MainScreenState extends State<MainScreen> {
             label: 'Practice',
           ),
         ],
-        selectedItemColor: Colors.blue,
-        unselectedItemColor: Colors.grey,
+        selectedItemColor: selectedC,
+        unselectedItemColor: unselectedC,
       ),
     );
   }

--- a/lib/practice_screen.dart
+++ b/lib/practice_screen.dart
@@ -12,6 +12,10 @@ import 'dart:math';
 import 'scrambledword_screen.dart';
 import 'connect_screen.dart';
 
+// Color definitions for PracticeScreen
+const Color iconC = Colors.grey;
+const Color textC = Colors.grey;
+
 const int kDefaultFlashcardCount = 20;
 
 class PracticeScreen extends StatefulWidget {
@@ -51,16 +55,16 @@ class _PracticeScreenState extends State<PracticeScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(Icons.school_outlined, size: 64, color: Colors.grey),
+              Icon(Icons.school_outlined, size: 64, color: iconC),
               SizedBox(height: 16),
               Text(
                 'No vocabularies available',
-                style: TextStyle(fontSize: 18, color: Colors.grey),
+                style: TextStyle(fontSize: 18, color: textC),
               ),
               SizedBox(height: 8),
               Text(
                 'Create a vocabulary first to start practicing',
-                style: TextStyle(color: Colors.grey),
+                style: TextStyle(color: textC),
               ),
             ],
           ),

--- a/lib/scrambledword_screen.dart
+++ b/lib/scrambledword_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'vocabulary.dart';
 import 'dart:math';
 
+// Color definitions for ScrambledWordScreen
+const Color correctBgC = Colors.greenAccent;
+const Color correctTextC = Colors.green;
+
 class ScrambledWordScreen extends StatefulWidget {
   final Vocabulary vocabulary;
   final int count;
@@ -128,7 +132,7 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
                           index: i,
                           child: Chip(
                             label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
-                            backgroundColor: _isCorrect ? Colors.greenAccent : null,
+                            backgroundColor: _isCorrect ? correctBgC : null,
                           ),
                         ),
                       ),
@@ -140,7 +144,7 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
             if (_isCorrect)
               Column(
                 children: [
-                  const Text('Correct!', style: TextStyle(color: Colors.green, fontSize: 20)),
+                  const Text('Correct!', style: TextStyle(color: correctTextC, fontSize: 20)),
                   const SizedBox(height: 8),
                   Text(
                     _quizEntries[_current].target,

--- a/lib/vocabulary_screen.dart
+++ b/lib/vocabulary_screen.dart
@@ -7,6 +7,12 @@ import 'dart:io';
 import 'package:csv/csv.dart';
 import 'practice_screen.dart';
 
+// Color definitions for VocabularyScreen
+const Color iconC = Colors.grey;
+const Color textC = Colors.grey;
+const Color text600C = Colors.grey[600]
+const Color bg100C = Colors.grey[100]
+
 
 class VocabularyListScreen extends StatefulWidget {
   const VocabularyListScreen({super.key});
@@ -69,16 +75,16 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.book_outlined, size: 64, color: Colors.grey),
+                  Icon(Icons.book_outlined, size: 64, color: iconC),
                   SizedBox(height: 16),
                   Text(
                     'No vocabularies yet',
-                    style: TextStyle(fontSize: 18, color: Colors.grey),
+                    style: TextStyle(fontSize: 18, color: textC),
                   ),
                   SizedBox(height: 8),
                   Text(
                     'Create your first vocabulary to get started',
-                    style: TextStyle(color: Colors.grey),
+                    style: TextStyle(color: textC),
                   ),
                 ],
               ),
@@ -373,7 +379,7 @@ class _VocabularyDetailScreenState extends State<VocabularyDetailScreen> {
         children: [
           Container(
             padding: const EdgeInsets.all(16),
-            color: Colors.grey[100],
+            color: bg100C,
             child: Row(
               children: [
                 Expanded(
@@ -386,7 +392,7 @@ class _VocabularyDetailScreenState extends State<VocabularyDetailScreen> {
                       ),
                       Text(
                         '${_vocabulary.entries.length} words',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: text600C),
                       ),
                     ],
                   ),
@@ -401,16 +407,16 @@ class _VocabularyDetailScreenState extends State<VocabularyDetailScreen> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.translate_outlined, size: 64, color: Colors.grey),
+                        Icon(Icons.translate_outlined, size: 64, color: iconC),
                         SizedBox(height: 16),
                         Text(
                           'No words yet',
-                          style: TextStyle(fontSize: 18, color: Colors.grey),
+                          style: TextStyle(fontSize: 18, color: textC),
                         ),
                         SizedBox(height: 8),
                         Text(
                           'Add your first word to get started',
-                          style: TextStyle(color: Colors.grey),
+                          style: TextStyle(color: textC),
                         ),
                       ],
                     ),

--- a/lib/vocabulary_screen.dart
+++ b/lib/vocabulary_screen.dart
@@ -10,8 +10,8 @@ import 'practice_screen.dart';
 // Color definitions for VocabularyScreen
 const Color iconC = Colors.grey;
 const Color textC = Colors.grey;
-const Color text600C = Colors.grey[600];
-const Color bg100C = Colors.grey[100];
+final Color text600C = Colors.grey[600]!;
+final Color bg100C = Colors.grey[100]!;
 
 
 class VocabularyListScreen extends StatefulWidget {

--- a/lib/vocabulary_screen.dart
+++ b/lib/vocabulary_screen.dart
@@ -10,8 +10,8 @@ import 'practice_screen.dart';
 // Color definitions for VocabularyScreen
 const Color iconC = Colors.grey;
 const Color textC = Colors.grey;
-const Color text600C = Colors.grey[600]
-const Color bg100C = Colors.grey[100]
+const Color text600C = Colors.grey[600];
+const Color bg100C = Colors.grey[100];
 
 
 class VocabularyListScreen extends StatefulWidget {

--- a/lib/vocabulary_screen.dart
+++ b/lib/vocabulary_screen.dart
@@ -10,8 +10,7 @@ import 'practice_screen.dart';
 // Color definitions for VocabularyScreen
 const Color iconC = Colors.grey;
 const Color textC = Colors.grey;
-final Color text600C = Colors.grey[600]!;
-final Color bg100C = Colors.grey[100]!;
+const Color bgC = Colors.white;
 
 
 class VocabularyListScreen extends StatefulWidget {
@@ -379,7 +378,7 @@ class _VocabularyDetailScreenState extends State<VocabularyDetailScreen> {
         children: [
           Container(
             padding: const EdgeInsets.all(16),
-            color: bg100C,
+            color: bgC,
             child: Row(
               children: [
                 Expanded(
@@ -392,7 +391,7 @@ class _VocabularyDetailScreenState extends State<VocabularyDetailScreen> {
                       ),
                       Text(
                         '${_vocabulary.entries.length} words',
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: text600C),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: textC),
                       ),
                     ],
                   ),

--- a/lib/wordsearch_screen.dart
+++ b/lib/wordsearch_screen.dart
@@ -3,6 +3,14 @@ import 'dart:math';
 import 'vocabulary.dart';
 import 'package:unicode_data/unicode_data.dart';
 
+// Color definitions for WordSearchScreen
+const Color foundC = Colors.greenAccent;
+const Color selectedC = Colors.yellowAccent;
+const Color borderC = Colors.blueGrey;
+const Color defaultC = Colors.white;
+const Color hintC = Colors.grey;
+const Color hintTextC = Colors.grey;
+
 class _PlacementOption {
   final int row;
   final int col;
@@ -515,12 +523,12 @@ class _WordSearchScreenState extends State<WordSearchScreen> {
                           height: cellSize,
                           margin: const EdgeInsets.all(2),
                           decoration: BoxDecoration(
-                            border: Border.all(color: Colors.blueGrey),
+                            border: Border.all(color: borderC),
                             color: isSelected
-                                ? Colors.yellowAccent
+                                ? selectedC
                                 : isFound
-                                    ? Colors.greenAccent
-                                    : Colors.white,
+                                    ? foundC
+                                    : defaultC,
                           ),
                           child: Center(
                             child: Text(
@@ -575,7 +583,7 @@ class _WordSearchScreenState extends State<WordSearchScreen> {
                                   padding: const EdgeInsets.only(top: 2.0),
                                   child: Chip(
                                     label: Text(word.target),
-                                    backgroundColor: Colors.greenAccent,
+                                    backgroundColor: foundC,
                                   ),
                                 ),
                             ],
@@ -588,13 +596,13 @@ class _WordSearchScreenState extends State<WordSearchScreen> {
                             children: [
                               Chip(
                                 label: Text(e.target),
-                                backgroundColor: found ? Colors.greenAccent : null,
+                                backgroundColor: found ? foundC : null,
                               ),
                               Padding(
                                 padding: const EdgeInsets.only(top: 2.0),
                                 child: Text(
                                   e.source,
-                                  style: TextStyle(fontSize: 12, color: Colors.grey[700]),
+                                  style: TextStyle(fontSize: 12, color: hintTextC),
                                 ),
                               ),
                             ],

--- a/test/screens/connect_screen_test.dart
+++ b/test/screens/connect_screen_test.dart
@@ -49,8 +49,8 @@ void main() {
       final targetBoxPreTap = tester.widget<Container>(find.ancestor(of: targetFinder, matching: find.byType(Container)).first);
       final BoxDecoration? sourceDecorationPreTap = sourceBoxPreTap.decoration as BoxDecoration?;
       final BoxDecoration? targetDecorationPreTap = targetBoxPreTap.decoration as BoxDecoration?;
-      expect(sourceDecorationPreTap?.color, equals(Colors.white));
-      expect(targetDecorationPreTap?.color, equals(Colors.white));
+      expect(sourceDecorationPreTap?.color, equals(boxC));
+      expect(targetDecorationPreTap?.color, equals(boxC));
 
       // Tap the source word
       await tester.tap(sourceFinder);
@@ -64,8 +64,8 @@ void main() {
       final targetBoxPostTap = tester.widget<Container>(find.ancestor(of: targetFinder, matching: find.byType(Container)).first);
       final BoxDecoration? sourceDecorationPostTap = sourceBoxPostTap.decoration as BoxDecoration?;
       final BoxDecoration? targetDecorationPostTap = targetBoxPostTap.decoration as BoxDecoration?;
-      expect(sourceDecorationPostTap?.color, equals(Colors.grey[300]));
-      expect(targetDecorationPostTap?.color, equals(Colors.grey[300]));
+      expect(sourceDecorationPostTap?.color, equals(boxConnectedC));
+      expect(targetDecorationPostTap?.color, equals(boxConnectedC));
 
       // Progress should update to 1/3
       expect(find.text('1/3'), findsOneWidget);

--- a/test/screens/connect_screen_test.dart
+++ b/test/screens/connect_screen_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lexikon/connect_screen.dart';
+
+void main() {
+  group('ConnectScreen', () {
+    final wordPairs = [
+      {'source': 'cat', 'target': 'chat'},
+      {'source': 'dog', 'target': 'chien'},
+      {'source': 'fish', 'target': 'poisson'},
+    ];
+
+    testWidgets('renders source and target words', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ConnectScreen(wordPairs: wordPairs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Should show all source words
+      for (final pair in wordPairs) {
+        expect(find.text(pair['source']!), findsOneWidget);
+      }
+      // Should show all target words (order may be shuffled)
+      for (final pair in wordPairs) {
+        expect(find.text(pair['target']!), findsOneWidget);
+      }
+      // Should show progress bar and progress text
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.text('0/3'), findsOneWidget);
+    });
+  });
+} 

--- a/test/screens/connect_screen_test.dart
+++ b/test/screens/connect_screen_test.dart
@@ -30,5 +30,46 @@ void main() {
       expect(find.byType(LinearProgressIndicator), findsOneWidget);
       expect(find.text('0/3'), findsOneWidget);
     });
+
+    testWidgets('can make a valid connection', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ConnectScreen(wordPairs: wordPairs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the first source word and its correct target
+      final firstPair = wordPairs[0];
+      final sourceFinder = find.text(firstPair['source']!);
+      final targetFinder = find.text(firstPair['target']!);
+
+      // Before tapping, the source and target should be enabled (not greyed out)
+      final sourceBoxPreTap = tester.widget<Container>(find.ancestor(of: sourceFinder, matching: find.byType(Container)).first);
+      final targetBoxPreTap = tester.widget<Container>(find.ancestor(of: targetFinder, matching: find.byType(Container)).first);
+      final BoxDecoration? sourceDecorationPreTap = sourceBoxPreTap.decoration as BoxDecoration?;
+      final BoxDecoration? targetDecorationPreTap = targetBoxPreTap.decoration as BoxDecoration?;
+      expect(sourceDecorationPreTap?.color, equals(Colors.white));
+      expect(targetDecorationPreTap?.color, equals(Colors.white));
+
+      // Tap the source word
+      await tester.tap(sourceFinder);
+      await tester.pumpAndSettle();
+      // Tap the correct target word
+      await tester.tap(targetFinder);
+      await tester.pumpAndSettle();
+
+      // After connecting, the source and target should be disabled (greyed out)
+      final sourceBoxPostTap = tester.widget<Container>(find.ancestor(of: sourceFinder, matching: find.byType(Container)).first);
+      final targetBoxPostTap = tester.widget<Container>(find.ancestor(of: targetFinder, matching: find.byType(Container)).first);
+      final BoxDecoration? sourceDecorationPostTap = sourceBoxPostTap.decoration as BoxDecoration?;
+      final BoxDecoration? targetDecorationPostTap = targetBoxPostTap.decoration as BoxDecoration?;
+      expect(sourceDecorationPostTap?.color, equals(Colors.grey[300]));
+      expect(targetDecorationPostTap?.color, equals(Colors.grey[300]));
+
+      // Progress should update to 1/3
+      expect(find.text('1/3'), findsOneWidget);
+      expect(find.text('0/3'), findsNothing);
+    });
   });
 } 

--- a/test/screens/flashcard_screen_test.dart
+++ b/test/screens/flashcard_screen_test.dart
@@ -78,7 +78,7 @@ void main() {
       final feedbackFinder = find.textContaining('Correct!');
       expect(feedbackFinder, findsOneWidget);
       final feedbackWidget = tester.widget<Text>(feedbackFinder);
-      expect(feedbackWidget.style?.color, Colors.green);
+      expect(feedbackWidget.style?.color, correctC);
 
       // Tap 'Next' to advance
       await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));
@@ -110,7 +110,7 @@ void main() {
       final feedbackFinder = find.textContaining('Incorrect.');
       expect(feedbackFinder, findsOneWidget);
       final feedbackWidget = tester.widget<Text>(feedbackFinder);
-      expect(feedbackWidget.style?.color, Colors.red);
+      expect(feedbackWidget.style?.color, incorrectC);
 
       // Tap 'Next' to advance
       await tester.tap(find.widgetWithText(ElevatedButton, 'Next'));

--- a/test/screens/wordsearch_screen_test.dart
+++ b/test/screens/wordsearch_screen_test.dart
@@ -162,7 +162,7 @@ void main() {
       for (final container in cellWidgets) {
         final decoration = container.decoration;
         if (decoration is BoxDecoration &&
-            decoration.color == Colors.yellowAccent) {
+            decoration.color == selectedC) {
           highlightedCount++;
         }
       }
@@ -280,9 +280,9 @@ void main() {
         final container = updatedCellWidgets[idx];
         final decoration = container.decoration;
         expect(
-          decoration is BoxDecoration && decoration.color == Colors.greenAccent,
+          decoration is BoxDecoration && decoration.color == foundC,
           isTrue,
-          reason: 'Cell ($row, $col) should be highlighted green',
+          reason: 'Cell ( $row, $col) should be highlighted green',
         );
       }
 
@@ -298,13 +298,13 @@ void main() {
         final decoration = container.decoration;
         if (k == 1) {
           expect(
-            decoration is BoxDecoration && decoration.color == Colors.yellowAccent,
+            decoration is BoxDecoration && decoration.color == selectedC,
             isTrue,
             reason: 'Cell for 2nd letter should be yellow after tap',
           );
         } else {
           expect(
-            decoration is BoxDecoration && decoration.color == Colors.greenAccent,
+            decoration is BoxDecoration && decoration.color == foundC,
             isTrue,
             reason: 'Other cells should remain green after tapping 2nd letter',
           );
@@ -326,7 +326,7 @@ void main() {
         final container = afterSecondTapWidgets[idx];
         final decoration = container.decoration;
         expect(
-          decoration is BoxDecoration && decoration.color == Colors.greenAccent,
+          decoration is BoxDecoration && decoration.color == foundC,
           isTrue,
           reason: 'Cell $idx should be green after tapping outside ΠΟΥΛΙ',
         );


### PR DESCRIPTION
- Unit tests for connect screen, closes #61 
- Refactor color names to be vars at the top of the screen and not hardcoded throughout the code files