### PR TITLE
Show horizontal scroll bar when scrambled letters are too long

### DIFF
--- a/lib/screens/practice/scrambledword_screen.dart
+++ b/lib/screens/practice/scrambledword_screen.dart
@@ -199,7 +199,7 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
                               ),
                               childWhenDragging: Material(
                                 child: Chip(
-                                  label: Text('', style: const TextStyle(fontSize: 24)),
+                                  label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
                                   backgroundColor: Colors.grey[300],
                                 ),
                               ),

--- a/lib/screens/practice/scrambledword_screen.dart
+++ b/lib/screens/practice/scrambledword_screen.dart
@@ -27,6 +27,7 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
   late List<String> _scrambledLetters;
   late List<String> _userOrder;
   bool _isCorrect = false;
+  late ScrollController _scrollController;
 
   /// Checks if a word can be meaningfully scrambled
   bool _canBeScrambled(String word) {
@@ -38,6 +39,7 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
   @override
   void initState() {
     super.initState();
+    _scrollController = ScrollController();
     // Filter out words that can't be meaningfully scrambled
     _quizEntries = widget.vocabulary.entries
         .where((entry) => _canBeScrambled(entry.target.trim()))
@@ -97,6 +99,12 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
         _setupCurrentWord();
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -168,25 +176,58 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
               height: 64,
               child: Directionality(
                 textDirection: widget.vocabulary.targetReadingDirection,
-                child: ReorderableListView(
-                  shrinkWrap: true,
-                  scrollDirection: Axis.horizontal,
-                  buildDefaultDragHandles: false,
-                  onReorder: _onReorder,
-                  children: [
-                    for (int i = 0; i < _userOrder.length; i++)
-                      Container(
-                        key: ValueKey('letter_$i'),
-                        margin: const EdgeInsets.symmetric(horizontal: 4),
-                        child: ReorderableDragStartListener(
-                          index: i,
-                          child: Chip(
-                            label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
-                            backgroundColor: _isCorrect ? correctBgC : null,
+                child: Scrollbar(
+                  controller: _scrollController,
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    controller: _scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        for (int i = 0; i < _userOrder.length; i++)
+                          Container(
+                            key: ValueKey('letter_$i'),
+                            margin: const EdgeInsets.symmetric(horizontal: 4),
+                            child: Draggable<String>(
+                              data: _userOrder[i],
+                              feedback: Material(
+                                child: Chip(
+                                  label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
+                                  backgroundColor: _isCorrect ? correctBgC : null,
+                                ),
+                              ),
+                              childWhenDragging: Material(
+                                child: Chip(
+                                  label: Text('', style: const TextStyle(fontSize: 24)),
+                                  backgroundColor: Colors.grey[300],
+                                ),
+                              ),
+                              child: DragTarget<String>(
+                                onWillAccept: (data) => data != null,
+                                onAccept: (data) {
+                                  setState(() {
+                                    final oldIndex = _userOrder.indexOf(data);
+                                    final newIndex = i;
+                                    if (oldIndex != -1 && oldIndex != newIndex) {
+                                      _userOrder.removeAt(oldIndex);
+                                      _userOrder.insert(newIndex, data);
+                                      _checkCorrect();
+                                    }
+                                  });
+                                },
+                                builder: (context, candidateData, rejectedData) {
+                                  return Chip(
+                                    label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
+                                    backgroundColor: _isCorrect ? correctBgC : null,
+                                  );
+                                },
+                              ),
+                            ),
                           ),
-                        ),
-                      ),
-                  ],
+                      ],
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/practice/scrambledword_screen.dart
+++ b/lib/screens/practice/scrambledword_screen.dart
@@ -172,64 +172,74 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
             const SizedBox(height: 32),
             Text('${widget.vocabulary.targetLanguage}:', style: Theme.of(context).textTheme.titleLarge),
             const SizedBox(height: 8),
-            SizedBox(
-              height: 64,
-              child: Directionality(
-                textDirection: widget.vocabulary.targetReadingDirection,
-                child: Scrollbar(
-                  controller: _scrollController,
-                  thumbVisibility: true,
-                  child: SingleChildScrollView(
-                    controller: _scrollController,
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        for (int i = 0; i < _userOrder.length; i++)
-                          Container(
-                            key: ValueKey('letter_$i'),
-                            margin: const EdgeInsets.symmetric(horizontal: 4),
-                            child: Draggable<String>(
-                              data: _userOrder[i],
-                              feedback: Material(
-                                child: Chip(
-                                  label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
-                                  backgroundColor: _isCorrect ? correctBgC : null,
-                                ),
-                              ),
-                              childWhenDragging: Material(
-                                child: Chip(
-                                  label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
-                                  backgroundColor: Colors.grey[300],
-                                ),
-                              ),
-                              child: DragTarget<String>(
-                                onWillAccept: (data) => data != null,
-                                onAccept: (data) {
-                                  setState(() {
-                                    final oldIndex = _userOrder.indexOf(data);
-                                    final newIndex = i;
-                                    if (oldIndex != -1 && oldIndex != newIndex) {
-                                      _userOrder.removeAt(oldIndex);
-                                      _userOrder.insert(newIndex, data);
-                                      _checkCorrect();
-                                    }
-                                  });
-                                },
-                                builder: (context, candidateData, rejectedData) {
-                                  return Chip(
-                                    label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
-                                    backgroundColor: _isCorrect ? correctBgC : null,
-                                  );
-                                },
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
+            Container(
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.grey.shade300),
+                borderRadius: BorderRadius.circular(8),
               ),
+                             child: Directionality(
+                 textDirection: widget.vocabulary.targetReadingDirection,
+                                   child: Container(
+                    height: 120,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                                                              child: Scrollbar(
+                       controller: _scrollController,
+                       thumbVisibility: MediaQuery.of(context).size.width > 600,
+                       trackVisibility: MediaQuery.of(context).size.width > 600,
+                       thickness: 8,
+                       radius: const Radius.circular(4),
+                       child: SingleChildScrollView(
+                         controller: _scrollController,
+                         scrollDirection: Axis.horizontal,
+                         child: Row(
+                           mainAxisAlignment: MainAxisAlignment.center,
+                           children: [
+                             for (int i = 0; i < _userOrder.length; i++)
+                               Container(
+                                 key: ValueKey('letter_$i'),
+                                 margin: const EdgeInsets.symmetric(horizontal: 8),
+                                 child: Draggable<String>(
+                                   data: _userOrder[i],
+                                   feedback: Material(
+                                     child: Chip(
+                                       label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
+                                       backgroundColor: _isCorrect ? correctBgC : null,
+                                     ),
+                                   ),
+                                   childWhenDragging: Material(
+                                     child: Chip(
+                                       label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
+                                       backgroundColor: Colors.grey[300],
+                                     ),
+                                   ),
+                                   child: DragTarget<String>(
+                                     onWillAccept: (data) => data != null,
+                                     onAccept: (data) {
+                                       setState(() {
+                                         final oldIndex = _userOrder.indexOf(data);
+                                         final newIndex = i;
+                                         if (oldIndex != -1 && oldIndex != newIndex) {
+                                           _userOrder.removeAt(oldIndex);
+                                           _userOrder.insert(newIndex, data);
+                                           _checkCorrect();
+                                         }
+                                       });
+                                     },
+                                     builder: (context, candidateData, rejectedData) {
+                                       return Chip(
+                                         label: Text(_userOrder[i], style: const TextStyle(fontSize: 24)),
+                                         backgroundColor: _isCorrect ? correctBgC : null,
+                                       );
+                                     },
+                                   ),
+                                 ),
+                               ),
+                           ],
+                         ),
+                       ),
+                     ),
+                  ),
+               ),
             ),
             const SizedBox(height: 24),
             if (_isCorrect)


### PR DESCRIPTION
Fixes #66 

This isn't entirely yet how I wanted it, because:

- on desktop, the bar only shows up after hovering with the mouse in the correct place
- on mobile, the bar shows only after scrolling with your fingers in the correct area, but then it shows on top of the letters.

But I couldn't find a better solution yet to suit both platforms, so it'll have to do for now, and at least it should be functional & more usable than before.