### PR TITLE
Add hint option to scramble exercise

### DIFF
--- a/lib/screens/practice/scrambledword_screen.dart
+++ b/lib/screens/practice/scrambledword_screen.dart
@@ -161,15 +161,6 @@ class _ScrambledWordScreenState extends State<ScrambledWordScreen> {
     }
     
     if (_current >= _quizEntries.length) {
-      // Update statistics for the last word if it was correct
-      if (_isCorrect) {
-        if (_hintUsed[_current - 1]) {
-          _correctWithHint++;
-        } else {
-          _correctWithoutHint++;
-        }
-      }
-      
       int totalCorrect = _correctWithoutHint + _correctWithHint;
       double percent = totalCorrect > 0 ? (_correctWithoutHint / totalCorrect) * 100 : 0;
       


### PR DESCRIPTION
- Each scrambled exercise shows a toggle "Show hint" that is off by default
- If you toggle it, it shows the full word
- At the end of the practice, it gives a score representing how many words % you were able to complete without hint

Fixes #67 